### PR TITLE
Use %20 as a separator in the search term rather than '+' as this is the format the app uses

### DIFF
--- a/src/test/scala/JsonRetrievalTests.scala
+++ b/src/test/scala/JsonRetrievalTests.scala
@@ -2,8 +2,8 @@ import org.scalatest._
 
 class JsonRetrievalTests extends FlatSpec with Matchers with BeforeAndAfterEach {
   "Search query URL" should "produce correct filename" in {
-    val filename = JsonEndpointRetrieval().generateFileName("http://mobile-apps.guardianapis.com/search?query=vladimir+putin")
-    filename.toString should be ("./cache/search?query=vladimir+putin.json")
+    val filename = JsonEndpointRetrieval().generateFileName("http://mobile-apps.guardianapis.com/search?query=vladimir%20putin")
+    filename.toString should be ("./cache/search?query=vladimir%20putin.json")
   }
 
   "Fronts URL" should "produce correct filename" in {


### PR DESCRIPTION
This isn't strictly necessary I've realised as the url is specified in Jenkins but for the sake of not having an invalid url in the codebase I think it's worth changing.